### PR TITLE
docker pull to use the cache when building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # This file is used by CI pipeline when testing this action
 FROM alpine:latest
 
+RUN apk -a info curl \
+  && apk add curl
+
 # these two are passed as build args and stored as env variables
 ARG BUILD_DATE
 ARG GITHUB_SHA

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 # This file is used by CI pipeline when testing this action
 FROM alpine:latest
 
-RUN apk -a info curl \
+RUN apk update \
+  && apk -a info curl \
   && apk add curl
 
 # these two are passed as build args and stored as env variables

--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,8 @@ runs:
         echo "Building the Docker image: ${{ inputs.repository }}/${{ inputs.image_name }}:${{ env.COMMIT_TAG }} ..."
         echo
 
+        docker pull ${{ inputs.repository }}/${{ inputs.image_name }}:latest
+
         COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 \
           docker build . \
           --cache-from ${{ inputs.repository }}/${{ inputs.image_name }}:latest \

--- a/action.yml
+++ b/action.yml
@@ -48,17 +48,20 @@ runs:
         # expand commands
         set -x
 
+        docker -v
+
         export BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
         echo
         echo "Building the Docker image: ${{ inputs.repository }}/${{ inputs.image_name }}:${{ env.COMMIT_TAG }} ..."
         echo
 
-        docker pull ${{ inputs.repository }}/${{ inputs.image_name }}:latest
-
-        COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 \
+        # https://docs.docker.com/develop/develop-images/build_enhancements/
+        # https://docs.docker.com/engine/reference/commandline/build/#specifying-external-cache-sources
+        DOCKER_BUILDKIT=1 \
           docker build . \
           --cache-from ${{ inputs.repository }}/${{ inputs.image_name }}:latest \
+          --build-arg BUILDKIT_INLINE_CACHE=1 \
           \
           --build-arg BUILD_DATE=${BUILD_DATE} \
           --build-arg GITHUB_SHA=${GITHUB_SHA} \


### PR DESCRIPTION
Before:

```
#7 importing cache manifest from ghcr.io/macbre/push-to-ghcr:latest
#7 sha256:1d4ca8774450a741d62962b8b28b232ad9aee1efaa99805caa52cfd51a32e4a5
#7 DONE 0.5s
```

After:

```
#5 [2/3] RUN apk update   && apk -a info curl   && apk add curl
#5 sha256:0e1ad6e468782c09ab55ce8e7d9b7f1d868148241bb9bb1c4f4d88bb29a494bc
#5 pulling sha256:5843afab387455b37944e709ee8c78d7520df80f8d01cf7f861aae63beeddb6b
#5 pulling sha256:b07e0b41ed636a792e89877dfe3996115f818bd0aaa3990dee7bb9198d4fe2eb
#5 pulling sha256:5843afab387455b37944e709ee8c78d7520df80f8d01cf7f861aae63beeddb6b 0.3s done
#5 pulling sha256:b07e0b41ed636a792e89877dfe3996115f818bd0aaa3990dee7bb9198d4fe2eb 0.5s done
#5 CACHED
```