### PR TITLE
dockerfile input: allow docker build --file to be customized

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,26 @@ jobs:
           docker pull ${IMAGE}
           docker image inspect ${IMAGE} | jq '.[].Config.Labels' | grep "${GITHUB_SHA}"
 
+  ghcr_with_dockerfile_in_subdir:
+    runs-on: "ubuntu-20.04"  # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run an action
+        uses: ./
+        with:
+          image_name: "foo/bar-app"
+          dockerfile: "./foo/bar/Dockerfile"
+          context: "./foo"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Make sure that an image has been built
+        env:
+          IMAGE: ghcr.io/foo/bar-app
+        run: |
+          docker images | grep ${IMAGE}
+
   ghcr_and_docker_io:
     runs-on: "ubuntu-20.04"  # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ jobs:
           # docker_io_token: ${{ secrets.DOCKER_IO_ACCESS_TOKEN }}  # see https://hub.docker.com/settings/security
 ```
 
-This action assumes that your `Dockerfile` is in the root directory of your repository.
+This action assumes that your **`Dockerfile` is in the root directory of your repository**.
+
+However, you can use `dockerfile` input to **specify a different path** (relative to the root directory of your repository). Additionaly, `context` input can also be provided. [Docker docs should provide more context on `context` ;)](https://docs.docker.com/engine/reference/commandline/build/).
 
 ## Labels and build args
 

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,11 @@ inputs:
     required: false
     default: "./Dockerfile"
 
+  context:
+    description: "A path to the context in which the build will happen, see https://docs.docker.com/engine/reference/commandline/build/"
+    required: false
+    default: "."
+
   repository:
     description: "Docker repository to push an image to, defaults to ghcr.io"
     required: true
@@ -61,11 +66,11 @@ runs:
         export BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
         export GITHUB_URL=https://github.com/${{ github.repository }}
 
-        echo "::group::Building the Docker image: ${{ inputs.repository }}/${{ inputs.image_name }}:${COMMIT_TAG} from ${{ inputs.dockerfile }}..."
+        echo "::group::Building the Docker image: ${{ inputs.repository }}/${{ inputs.image_name }}:${COMMIT_TAG} from ${{ inputs.dockerfile }} in ${{ inputs.context}} context ..."
 
         # https://docs.docker.com/develop/develop-images/build_enhancements/
         # https://docs.docker.com/engine/reference/commandline/build/#specifying-external-cache-sources
-        >&0 docker build . \
+        >&0 docker build \
           --file ${{ inputs.dockerfile }} \
           --progress tty \
           --cache-from ${{ inputs.repository }}/${{ inputs.image_name }}:latest \
@@ -83,7 +88,8 @@ runs:
           \
           --label org.opencontainers.image.created=${BUILD_DATE} \
           --label org.opencontainers.image.source=${GITHUB_URL} \
-          --label org.opencontainers.image.revision=${GITHUB_SHA}
+          --label org.opencontainers.image.revision=${GITHUB_SHA} \
+          ${{ inputs.context }}
 
         echo "::endgroup::"
 

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,11 @@ inputs:
     description: "Image name, e.g. my-user-name/my-repo"
     required: true
 
+  dockerfile:
+    description: "A path to the Dockerfile (if it's not in the repository's root directory)"
+    required: false
+    default: "./Dockerfile"
+
   repository:
     description: "Docker repository to push an image to, defaults to ghcr.io"
     required: true
@@ -56,11 +61,12 @@ runs:
         export BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
         export GITHUB_URL=https://github.com/${{ github.repository }}
 
-        echo "::group::Building the Docker image: ${{ inputs.repository }}/${{ inputs.image_name }}:${COMMIT_TAG} ..."
+        echo "::group::Building the Docker image: ${{ inputs.repository }}/${{ inputs.image_name }}:${COMMIT_TAG} from ${{ inputs.dockerfile }}..."
 
         # https://docs.docker.com/develop/develop-images/build_enhancements/
         # https://docs.docker.com/engine/reference/commandline/build/#specifying-external-cache-sources
         >&0 docker build . \
+          --file ${{ inputs.dockerfile }} \
           --progress tty \
           --cache-from ${{ inputs.repository }}/${{ inputs.image_name }}:latest \
           --build-arg BUILDKIT_INLINE_CACHE=1 \

--- a/foo/bar/Dockerfile
+++ b/foo/bar/Dockerfile
@@ -1,0 +1,7 @@
+# This file is used by CI pipeline when testing this action
+FROM alpine:latest
+
+WORKDIR /opt
+COPY foo.txt /opt
+
+RUN cat foo.txt

--- a/foo/foo.txt
+++ b/foo/foo.txt
@@ -1,0 +1,1 @@
+Hi! It's me, foo.txt. Don't you remember me?


### PR DESCRIPTION
Add `dockerfile` and `context` inputs to allow building `Dockerfile` from subdirectories and providing the build context other than the root directory.

See https://docs.docker.com/engine/reference/commandline/build/

<img width="829" alt="Screenshot 2021-11-22 at 14 06 09" src="https://user-images.githubusercontent.com/1929317/142866902-90cba7eb-aea8-43b3-8db1-4f5f2121cb53.png">
