### PR TITLE
Let's report "NOT pushing the Docker image to docker.io" as a notice

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -118,7 +118,7 @@ runs:
         echo "::endgroup::"
 
         if [ -z "${DOCKER_IO_TOKEN}" ]; then
-          echo "::warning::NOT pushing the Docker image to docker.io ... Provide 'docker_io_token' if needed."
+          echo "::notice::NOT pushing the Docker image to docker.io ... Provide 'docker_io_token' if needed."
         else
           echo "::group::Pushing the Docker image to docker.io ..."
           echo "${DOCKER_IO_TOKEN}" | docker login docker.io -u "${{ github.actor }}" --password-stdin


### PR DESCRIPTION
Instead of a warning.

Resolves #21

## Example

<img width="819" alt="Screenshot 2022-11-17 at 17 12 42" src="https://user-images.githubusercontent.com/1929317/202512427-537edc1c-4e2e-44e3-a14a-d3d569bbebd3.png">

<img width="684" alt="Screenshot 2022-11-17 at 17 13 47" src="https://user-images.githubusercontent.com/1929317/202512692-cb8fd131-d295-41f8-870e-3ec82176f6a3.png">

/cc @kthy
