### PR TITLE
Push Multiple Tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#defining-access-for-the-github_token-scopes
 permissions: write-all
 
+env:
+  IMAGE_NAME: ${{ github.repository_owner }}/push-to-ghcr
+
 jobs:
   ghcr:
     runs-on: "ubuntu-latest"  # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on 
@@ -18,20 +21,20 @@ jobs:
       - name: Run an action
         uses: ./
         with:
-          image_name: "MaCBre/Push-to-ghcr" # make sure this is lowercased by the action
+          image_name: ${{ env.IMAGE_NAME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           image_tag: foo_tag
 
       - name: Make sure that an image has been built and tagged properly
         env:
-          IMAGE: ghcr.io/${{ github.repository }}
+          IMAGE: ghcr.io/${{ env.IMAGE_NAME }}
         run: |
           docker images | grep ${IMAGE}
           docker images | grep foo_tag
 
       - name: Make sure that an image has been pushed and is properly labelled
         env:
-          IMAGE: ghcr.io/${{ github.repository }}
+          IMAGE: ghcr.io/${{ env.IMAGE_NAME }}
         run: |
           set -x
           docker rmi ${IMAGE}:foo_tag
@@ -47,7 +50,7 @@ jobs:
       - name: Run an action
         uses: ./
         with:
-          image_name: "MaCBre/Push-to-ghcr" # make sure this is lowercased by the action
+          image_name: ${{ env.IMAGE_NAME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           image_tag: foo_tag
           # use this input to pass extra arguments to 'docker build'
@@ -55,7 +58,7 @@ jobs:
 
       - name: Make sure that an image has been built and tagged properly
         env:
-          IMAGE: ghcr.io/${{ github.repository }}
+          IMAGE: ghcr.io/${{ env.IMAGE_NAME }}
         run: |
           set -x
           docker images | grep ${IMAGE}
@@ -71,14 +74,14 @@ jobs:
       - name: Run an action
         uses: ./
         with:
-          image_name: "${{ github.repository_owner }}/push-to-ghcr-multi"
+          image_name: "${{ env.IMAGE_NAME }}-multi"
           github_token: ${{ secrets.GITHUB_TOKEN }}
           image_tag: 'multi_tag_primary, multi_tag_latest'
           docker_io_token: ${{ secrets.DOCKER_IO_ACCESS_TOKEN }}  # see https://hub.docker.com/settings/security
 
       - name: Make sure that all image tags have been built and pushed
         env:
-          IMAGE: ${{ github.repository_owner }}/push-to-ghcr-multi
+          IMAGE: ${{ env.IMAGE_NAME }}-multi
         run: |
           set -x
           docker images | grep ghcr.io/${IMAGE}
@@ -135,19 +138,19 @@ jobs:
       - name: Run an action
         uses: ./
         with:
-          image_name: ${{ github.repository }}
+          image_name: ${{ env.IMAGE_NAME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           docker_io_token: ${{ secrets.DOCKER_IO_ACCESS_TOKEN }}  # see https://hub.docker.com/settings/security
 
       - name: Make sure that an image has been built
         env:
-          IMAGE: ${{ github.repository }}
+          IMAGE: ${{ env.IMAGE_NAME }}
         run: |
           docker images | grep ${IMAGE}
 
       - name: Make sure that an image has been pushed and is properly labelled
         env:
-          IMAGE: ${{ github.repository }}
+          IMAGE: ${{ env.IMAGE_NAME }}
         run: |
           set -x
           docker rmi ghcr.io/${IMAGE}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,8 @@ jobs:
           image_name: "MaCBre/Push-to-ghcr" # make sure this is lowercased by the action
           github_token: ${{ secrets.GITHUB_TOKEN }}
           image_tag: foo_tag
-          # use this input to pass extra arguments to 'docker build', e.g. use multiple tags for an image
-          extra_args: '--tag foo.net/app:latest --annotation "foo=bar"'
+          # use this input to pass extra arguments to 'docker build'
+          extra_args: '--label extra-args-test=foo'
 
       - name: Make sure that an image has been built and tagged properly
         env:
@@ -60,7 +60,49 @@ jobs:
           set -x
           docker images | grep ${IMAGE}
           docker images | grep foo_tag
-          docker images | grep 'foo.net/app'
+          docker image inspect ${IMAGE}:foo_tag | jq '.[].Config.Labels' | tee /dev/fd/2 | grep '"extra-args-test": "foo"'
+
+  ghcr_and_docker_io_with_multiple_image_tags:
+    runs-on: "ubuntu-latest"  # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run an action
+        uses: ./
+        with:
+          image_name: "${{ github.repository_owner }}/push-to-ghcr-multi"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          image_tag: 'multi_tag_primary, multi_tag_latest'
+          docker_io_token: ${{ secrets.DOCKER_IO_ACCESS_TOKEN }}  # see https://hub.docker.com/settings/security
+
+      - name: Make sure that all image tags have been built and pushed
+        env:
+          IMAGE: ${{ github.repository_owner }}/push-to-ghcr-multi
+        run: |
+          set -x
+          docker images | grep ghcr.io/${IMAGE}
+          docker images | grep multi_tag_primary
+          docker images | grep multi_tag_latest
+          docker image inspect ghcr.io/${IMAGE}:multi_tag_primary
+          docker image inspect ghcr.io/${IMAGE}:multi_tag_latest
+          docker image inspect docker.io/${IMAGE}:multi_tag_primary
+          docker image inspect docker.io/${IMAGE}:multi_tag_latest
+
+          docker rmi ghcr.io/${IMAGE}:multi_tag_primary
+          docker rmi ghcr.io/${IMAGE}:multi_tag_latest
+          docker rmi docker.io/${IMAGE}:multi_tag_primary
+          docker rmi docker.io/${IMAGE}:multi_tag_latest
+
+          docker pull ghcr.io/${IMAGE}:multi_tag_primary
+          docker pull ghcr.io/${IMAGE}:multi_tag_latest
+          docker pull docker.io/${IMAGE}:multi_tag_primary
+          docker pull docker.io/${IMAGE}:multi_tag_latest
+
+          docker image inspect ghcr.io/${IMAGE}:multi_tag_primary | jq '.[].Config.Labels' | tee /dev/fd/2 | grep "${GITHUB_SHA}"
+          docker image inspect ghcr.io/${IMAGE}:multi_tag_latest | jq '.[].Config.Labels' | tee /dev/fd/2 | grep "${GITHUB_SHA}"
+          docker image inspect docker.io/${IMAGE}:multi_tag_primary | jq '.[].Config.Labels' | tee /dev/fd/2 | grep "${GITHUB_SHA}"
+          docker image inspect docker.io/${IMAGE}:multi_tag_latest | jq '.[].Config.Labels' | tee /dev/fd/2 | grep "${GITHUB_SHA}"
 
   ghcr_with_dockerfile_in_subdir:
     runs-on: "ubuntu-latest"  # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,37 @@ jobs:
           docker image inspect ${IMAGE}:multi_tag_newline_primary
           docker image inspect ${IMAGE}:multi_tag_newline_latest
 
+  ghcr_with_uppercase_image_name:
+    runs-on: "ubuntu-latest"  # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set mixed-case image name
+        run: |
+          MIXED_OWNER=$(echo "${{ github.repository_owner }}" | awk '{
+            out = ""
+            for (i = 1; i <= length($0); i++) {
+              c = substr($0, i, 1)
+              out = out ((i % 2) ? toupper(c) : tolower(c))
+            }
+            print out
+          }')
+          echo "IMAGE_NAME_MIXED=${MIXED_OWNER}/Push-to-ghcr" >> "${GITHUB_ENV}"
+
+      - name: Run an action
+        uses: ./
+        with:
+          image_name: ${{ env.IMAGE_NAME_MIXED }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          image_tag: uppercase_image_name
+
+      - name: Make sure that the image name has been lowercased
+        env:
+          IMAGE: ghcr.io/${{ env.IMAGE_NAME }}
+        run: |
+          docker image inspect ${IMAGE}:uppercase_image_name
+
   ghcr_with_dockerfile_in_subdir:
     runs-on: "ubuntu-latest"  # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
       - name: Run an action with multi-platform build
         uses: ./
         with:
-          image_name: "macbre/push-to-ghcr"
+          image_name: ${{ env.IMAGE_NAME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           image_tag: foo_tag_multiplatform
           platforms: "linux/amd64,linux/arm64"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,28 @@ jobs:
           docker image inspect docker.io/${IMAGE}:multi_tag_primary | jq '.[].Config.Labels' | tee /dev/fd/2 | grep "${GITHUB_SHA}"
           docker image inspect docker.io/${IMAGE}:multi_tag_latest | jq '.[].Config.Labels' | tee /dev/fd/2 | grep "${GITHUB_SHA}"
 
+  ghcr_with_multiple_image_tags_newline:
+    runs-on: "ubuntu-latest"  # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run an action
+        uses: ./
+        with:
+          image_name: "${{ env.IMAGE_NAME }}-multi-newline"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          image_tag: |
+            multi_tag_newline_primary
+            multi_tag_newline_latest
+
+      - name: Make sure that all image tags have been built
+        env:
+          IMAGE: ghcr.io/${{ env.IMAGE_NAME }}-multi-newline
+        run: |
+          docker image inspect ${IMAGE}:multi_tag_newline_primary
+          docker image inspect ${IMAGE}:multi_tag_newline_latest
+
   ghcr_with_dockerfile_in_subdir:
     runs-on: "ubuntu-latest"  # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 # This file is used by CI pipeline when testing this action
 FROM alpine:latest
 
-RUN apk update \
-  && apk -a info curl \
-  && apk add curl
+RUN apk add --no-cache curl
 
 # these two are passed as build args
 ARG BUILD_DATE

--- a/README.md
+++ b/README.md
@@ -64,8 +64,32 @@ However, you can use `dockerfile` input to **specify a different path** (relativ
 * `repository` (defaults to `ghcr.io`): containers repository to push an image to
 * `docker_io_user`: A username to use when pushing an image to `docker.io` (defaults to the `github.actor`)
 * `docker_io_token`: Your `docker.io` token created via https://hub.docker.com/settings/security
-* `image_tag`: Image tag, e.g. `latest`. Will overwrite the tag latest tag on a push, and have no effect on a release
-* `extra_args`: additinal arguments to pass to `docker build`, you can for instance pass here additional tags to be used for an image, e.g. (`extra_args: "--tag foo:latest --tag app:bar"`)
+* `image_tag`: Image tag or tags, e.g. `latest` or `1.0.0,latest`. Will overwrite the latest tag on a push, and have no effect on a release. Only tag names are accepted, not full image references.
+* `extra_args`: additional arguments to pass to `docker build`. Tags added with `extra_args` are local build tags; use `image_tag` to publish multiple tags.
+
+### Publishing multiple tags
+
+For non-release events, `image_tag` can be a single tag, a comma-separated list, or a newline-separated list:
+
+```yaml
+      - name: Build and publish a Docker image for ${{ github.repository }}
+        uses: macbre/push-to-ghcr@master
+        with:
+          image_name: ${{ github.repository }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          image_tag: 1.0.0,latest
+```
+
+```yaml
+      - name: Build and publish a Docker image for ${{ github.repository }}
+        uses: macbre/push-to-ghcr@master
+        with:
+          image_name: ${{ github.repository }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          image_tag: |
+            1.0.0
+            latest
+```
 
 ## Labels and build args
 

--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ inputs:
     required: false
   
   image_tag:
-    description: Image tag, e.g. latest. Will overwrite the tag latest tag on a push, and have no effect on a release.
+    description: Image tag or tags, e.g. latest or "1.0.0,latest". Only tag names are accepted. Will overwrite the latest tag on a push, and have no effect on a release.
     required: false
 
   # https://docs.docker.com/build/guide/build-args/
@@ -49,7 +49,7 @@ inputs:
     default: "FOO=bar"
 
   extra_args:
-    description: Additional arguments to be passed to "docker build", you can pass custom tags here for instance.
+    description: Additional arguments to be passed to "docker build".
     required: false
     default: ""
 runs:
@@ -79,25 +79,65 @@ runs:
         # https://docs.github.com/en/actions/reference/contexts-reference
         echo "Event received: '${{ github.event_name }}' (with a reference '${{ github.ref }}' / tag name '${{ github.event.release.tag_name }}')"
 
+        IMAGE_TAGS=()
+        add_image_tag() {
+          if [ -z "$1" ]; then
+            return
+          fi
+
+          if [[ "$1" == *"/"* || "$1" == *":"* ]]; then
+            echo "::error::The image_tag input accepts tag names only, not full image references: '$1'"
+            exit 1
+          fi
+
+          for EXISTING_TAG in "${IMAGE_TAGS[@]}"; do
+            if [ "${EXISTING_TAG}" = "$1" ]; then
+              return
+            fi
+          done
+
+          IMAGE_TAGS+=("$1")
+        }
+
         if [ "${{ github.event_name }}" = "release" ]; then
           export COMMIT_TAG="${{ github.event.release.tag_name }}"
           export COMMIT_TAG=${COMMIT_TAG//v/}
+          add_image_tag "${COMMIT_TAG}"
         else
-          if [ -z ${IMAGE_TAG} ]; then
+          if [ -z "${IMAGE_TAG}" ]; then
             export COMMIT_TAG=latest
+            add_image_tag "${COMMIT_TAG}"
           else
-            export COMMIT_TAG=${IMAGE_TAG}
+            export IMAGE_TAG_LIST=${IMAGE_TAG//,/ }
+
+            for TAG in ${IMAGE_TAG_LIST}; do
+              add_image_tag "${TAG}"
+            done
+
+            if [ ${#IMAGE_TAGS[@]} -eq 0 ]; then
+              echo "::error::The image_tag input did not contain any tags."
+              exit 1
+            fi
+
+            export COMMIT_TAG=${IMAGE_TAGS[0]}
           fi
         fi
         
         # lowercase the image name, see https://github.com/macbre/push-to-ghcr/issues/12
         export IMAGE_NAME=$(echo ${IMAGE_NAME} | tr '[:upper:]' '[:lower:]')
 
-        echo "Tagging with ${COMMIT_TAG}"
+        echo "Tagging with ${IMAGE_TAGS[*]}"
         echo "::endgroup::"
 
         export BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
         export GITHUB_URL=https://github.com/${{ github.repository }}
+        GHCR_TAG_ARGS=()
+        DOCKER_IO_TAG_ARGS=()
+
+        for TAG in "${IMAGE_TAGS[@]}"; do
+          GHCR_TAG_ARGS+=(--tag "${{ inputs.repository }}/${IMAGE_NAME}:${TAG}")
+          DOCKER_IO_TAG_ARGS+=(--tag "docker.io/${IMAGE_NAME}:${TAG}")
+        done
 
         echo "::group::Building the Docker image: ${{ inputs.repository }}/${IMAGE_NAME}:${COMMIT_TAG} from ${{ inputs.dockerfile }} in ${{ inputs.context }} context ..."
 
@@ -114,8 +154,8 @@ runs:
           \
           --build-arg ${{ inputs.build_arg }} \
           \
-          --tag ${{ inputs.repository }}/${IMAGE_NAME}:${COMMIT_TAG} \
-          --tag docker.io/${IMAGE_NAME}:${COMMIT_TAG} \
+          "${GHCR_TAG_ARGS[@]}" \
+          "${DOCKER_IO_TAG_ARGS[@]}" \
           ${{ inputs.extra_args }} \
           \
           --label org.label-schema.build-date=${BUILD_DATE} \
@@ -142,7 +182,9 @@ runs:
         echo "::endgroup::"
 
         echo "::group::Pushing the Docker image to ${{ inputs.repository }} ..."
-        >&0 docker push ${{ inputs.repository }}/${IMAGE_NAME}:${COMMIT_TAG} && echo "Pushed"
+        for TAG in "${IMAGE_TAGS[@]}"; do
+          >&0 docker push ${{ inputs.repository }}/${IMAGE_NAME}:${TAG} && echo "Pushed ${{ inputs.repository }}/${IMAGE_NAME}:${TAG}"
+        done
         echo "::endgroup::"
 
         if [ -z "${DOCKER_IO_TOKEN}" ]; then
@@ -155,7 +197,9 @@ runs:
           echo "::group::Pushing the Docker image to docker.io as ${DOCKER_IO_USER}..."
           echo "${DOCKER_IO_TOKEN}" | docker login docker.io -u "${DOCKER_IO_USER}" --password-stdin
 
-          >&0 docker push docker.io/${IMAGE_NAME}:${COMMIT_TAG} && echo "Pushed"
+          for TAG in "${IMAGE_TAGS[@]}"; do
+            >&0 docker push docker.io/${IMAGE_NAME}:${TAG} && echo "Pushed docker.io/${IMAGE_NAME}:${TAG}"
+          done
 
           echo "::endgroup::"
         fi


### PR DESCRIPTION
Closes #50

This PR fixes multi-tag publishing while keeping the existing action inputs backwards compatible.

Changes:

- `image_tag` allows single tag, and CSV / newline-separated tags
- pushes every parsed `image_tag` value to GHCR and Docker Hub when configured
- keeps `extra_args` as a raw `docker build` passthrough
- README updates to reflect new `image_tag` behavior and no longer recommend `extra_args` as the way to do multi-tag
- CI coverage for CSV / newline tag parsing and publishing
- CI test for `extra_args` only validates passthrough args, not tags
- CI IMAGE_NAME variable defaulting to repo owner, making future forks easier to get set up
- CI add an explicit mixed-case image name test: the default repo owner value is not guaranteed to be mixed case, and I didn't want to lose the intent of the casing in the original hard-coded values.

Please let me know if you’re happy with the CI image-name changes. I can roll that back if you’d prefer to keep the CI diff narrower, but I included it so this workflow can run from forks while preserving the original mixed-case lowercasing coverage. :smile: 